### PR TITLE
Tools registered for the project not developer

### DIFF
--- a/Source/EditorScriptingTools/Private/EditorScriptingToolsSubsystem/EditorScriptingToolsSubsystem.cpp
+++ b/Source/EditorScriptingTools/Private/EditorScriptingToolsSubsystem/EditorScriptingToolsSubsystem.cpp
@@ -74,7 +74,7 @@ void UEditorScriptingToolsSubsystem::NotifySettingsModified(bool bSaveConfig /*=
 {
 	if (bSaveConfig)
 	{
-		SaveConfig();
+		SaveConfig(CPF_Config, *GetDefaultConfigFilename());
 	}
 
 	FEditorScriptingToolsDelegates::RefreshEditorScriptingToolsTabDelegate.Broadcast();

--- a/Source/EditorScriptingTools/Private/EditorScriptingToolsSubsystem/EditorScriptingToolsSubsystem.h
+++ b/Source/EditorScriptingTools/Private/EditorScriptingToolsSubsystem/EditorScriptingToolsSubsystem.h
@@ -11,8 +11,7 @@
 #include "UserDefinedPlacementCategoriesTypes.h"
 #include "EditorScriptingToolsSubsystem.generated.h"
 
-
-UCLASS(config = EditorPerProjectUserSettings)
+UCLASS(config = EditorScriptingTools, defaultconfig)
 class UEditorScriptingToolsSubsystem : public UEditorSubsystem
 {
 	GENERATED_BODY()

--- a/Source/EditorScriptingTools/Private/EditorScriptingToolsSubsystem/EditorScriptingToolsSubsystem.h
+++ b/Source/EditorScriptingTools/Private/EditorScriptingToolsSubsystem/EditorScriptingToolsSubsystem.h
@@ -11,7 +11,7 @@
 #include "UserDefinedPlacementCategoriesTypes.h"
 #include "EditorScriptingToolsSubsystem.generated.h"
 
-UCLASS(config = EditorScriptingTools, defaultconfig)
+UCLASS(config = EditorScriptingTools, DefaultConfig)
 class UEditorScriptingToolsSubsystem : public UEditorSubsystem
 {
 	GENERATED_BODY()


### PR DESCRIPTION
Currently, when you register a tool it is only registered for your own local editor.
This change registers the tool at the project level, so collaborators don't have to manually register/unregister tools when they become available.

We've been using these settings, and they've been working. 
Settings are stored in `Project/Config/DefaultEditorScriptingTools.ini`

@HoussineMehnik you outlined this change here https://github.com/HoussineMehnik/UE4-EditorScriptingToolsPlugin/issues/16

