### PR TITLE
Add `DrawCylinder` & `DrawWireCylinder`

### DIFF
--- a/Source/EditorScriptingTools/Private/EditorScriptingToolsCommon/LevelEditorToolBase.cpp
+++ b/Source/EditorScriptingTools/Private/EditorScriptingToolsCommon/LevelEditorToolBase.cpp
@@ -90,6 +90,16 @@ void ULevelEditorToolBase::DrawSpline(FDummyStruct DrawPrimitivesContext, USplin
 	LevelViewportPrimitiveDrawingUtils::DrawSpline(GetDrawPrimitivesContext(), SplineComponent, LineColor, DepthPriorityGroup);
 }
 
+void ULevelEditorToolBase::DrawCylinder(FDummyStruct DrawPrimitivesContext, const class UMaterialInterface* Material, const FVector& Center, const FRotator& Rotation, float Radius, float HalfHeight, int32 NumSides, EDepthPriorityGroup DepthPriorityGroup, float DepthBias)
+{
+	LevelViewportPrimitiveDrawingUtils::DrawCylinder(GetDrawPrimitivesContext(), Center, Rotation, Material, Radius, HalfHeight, NumSides, DepthPriorityGroup, DepthBias);
+}
+
+void ULevelEditorToolBase::DrawWireCylinder(FDummyStruct DrawPrimitivesContext, const FVector& Center, const FRotator& Rotation, float Radius, float HalfHeight, int32 NumSides /*= 16*/, FLinearColor Color /*= FLinearColor::White*/, EDepthPriorityGroup DepthPriorityGroup /*= EDepthPriorityGroup::World*/, float Thickness /*= 0.0f*/, float DepthBias /*= 0.0f*/)
+{
+	LevelViewportPrimitiveDrawingUtils::DrawWireCylinder(GetDrawPrimitivesContext(), Center, Rotation, Color, Radius, HalfHeight, NumSides, DepthPriorityGroup, Thickness, DepthBias);
+}
+
 /** ~Level Viewport Canvas  Drawing *********************************************************************************************************************************************/
 /********************************************************************************************************************************************************************************/
 

--- a/Source/EditorScriptingTools/Private/EditorScriptingToolsCommon/LevelEditorToolBase.h
+++ b/Source/EditorScriptingTools/Private/EditorScriptingToolsCommon/LevelEditorToolBase.h
@@ -70,6 +70,12 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "LevelEditingViewport|DrawPrimitives", meta = (HideSelfPin = "true"))
 		void DrawSpline(FDummyStruct DrawPrimitivesContext, USplineComponent* SplineComponent, FLinearColor LineColor = FLinearColor::White, EDepthPriorityGroup DepthPriorityGroup = EDepthPriorityGroup::World);
 
+	UFUNCTION(BlueprintCallable, Category = "LevelEditingViewport|DrawPrimitives", meta = (HideSelfPin = "true"))
+		void DrawCylinder(FDummyStruct DrawPrimitivesContext, const class UMaterialInterface* Material, const FVector& Center, const FRotator& Rotation, float Radius, float HalfHeight, int32 NumSides = 16, EDepthPriorityGroup DepthPriorityGroup = EDepthPriorityGroup::World, float DepthBias = 0.0f);
+
+	UFUNCTION(BlueprintCallable, Category = "LevelEditingViewport|DrawPrimitives", meta = (HideSelfPin = "true"))
+		void DrawWireCylinder(FDummyStruct DrawPrimitivesContext, const FVector& Center, const FRotator& Rotation, float Radius, float HalfHeight, int32 NumSides = 16, FLinearColor Color = FLinearColor::White, EDepthPriorityGroup DepthPriorityGroup = EDepthPriorityGroup::World, float Thickness = 0.0f, float DepthBias = 0.0f);
+
 
 	//~ Level Viewport Canvas  Drawing ********************************************************************************************************************************************/
 

--- a/Source/EditorScriptingTools/Private/Utils/LevelViewportPrimitiveDrawingUtils.cpp
+++ b/Source/EditorScriptingTools/Private/Utils/LevelViewportPrimitiveDrawingUtils.cpp
@@ -101,10 +101,11 @@ namespace LevelViewportPrimitiveDrawingUtils
 	{
 		if (FPrimitiveDrawInterface* PDI = Context.PDI)
 		{
+			const FMaterialRenderProxy* MaterialRenderProxy = Material != nullptr ? Material->GetRenderProxy() : GEditor->ArrowMaterial->GetRenderProxy();
 			const FVector X = Rotation.Vector();
 			const FVector Y = FRotationMatrix(Rotation).GetScaledAxis(EAxis::Y);
 			const FVector Z = FRotationMatrix(Rotation).GetScaledAxis(EAxis::Z);
-			//::DrawCylinder(PDI, Center, X, Y, Z, Radius, HalfHeight, NumSides, Material, ENUM_TO_UINT8(DepthPriorityGroup));
+			::DrawCylinder(PDI, FMatrix::Identity, Center, X, Y, Z, Radius, HalfHeight, NumSides, MaterialRenderProxy, CAST_TO_UINT8(DepthPriorityGroup));
 		}
 	}
 

--- a/Source/EditorScriptingTools/Private/Utils/LevelViewportPrimitiveDrawingUtils.cpp
+++ b/Source/EditorScriptingTools/Private/Utils/LevelViewportPrimitiveDrawingUtils.cpp
@@ -97,7 +97,7 @@ namespace LevelViewportPrimitiveDrawingUtils
 		}
 	}
 
-	void DrawCylinder(const FDrawPrimitivesContext& Context, const FVector& Center, const FRotator& Rotation, UMaterialInterface* Material, float Radius, float HalfHeight, uint32 NumSides, EDepthPriorityGroup DepthPriorityGroup, float DepthBias)
+	void DrawCylinder(const FDrawPrimitivesContext& Context, const FVector& Center, const FRotator& Rotation, const UMaterialInterface* Material, float Radius, float HalfHeight, uint32 NumSides, EDepthPriorityGroup DepthPriorityGroup, float DepthBias)
 	{
 		if (FPrimitiveDrawInterface* PDI = Context.PDI)
 		{


### PR DESCRIPTION
Adds draw functions:
- `DrawCylinder`
- `DrawWireCylinder`
These were already written into the `ULevelViewportPrimitiveDrawingUtils`, but were missing in `ULevelEditorToolBase`

Also fixed a mismatch in the `ULevelViewportPrimitiveDrawingUtils::DrawCylinder` signature