### PR TITLE
Update Object pointers to use `TObjectPtr`

### DIFF
--- a/Source/EditorScriptingTools/Private/DetailCustomization/DetailCustomizationInstance.h
+++ b/Source/EditorScriptingTools/Private/DetailCustomization/DetailCustomizationInstance.h
@@ -30,7 +30,7 @@ class   UDetailCustomizationInstance : public UObject
 
 public:
 	UPROPERTY()
-		TArray<UObject*> ReferencedObjects;
+	TArray<TObjectPtr<UObject>> ReferencedObjects;
 
 	/** Called when details should be customized */
 	UFUNCTION(BlueprintImplementableEvent, Category = "Detail Customization", meta = (DisplayName = "On Customize Details"))

--- a/Source/EditorScriptingTools/Private/EditorScriptingToolsCommon/EditorTypesWrapperTypes.h
+++ b/Source/EditorScriptingTools/Private/EditorScriptingToolsCommon/EditorTypesWrapperTypes.h
@@ -375,13 +375,13 @@ struct FActorComponentWrapper
 
 public:
 	FActorComponentWrapper() : ActorComponent(nullptr) {}
-	FActorComponentWrapper(const UActorComponent* InActorComp) : ActorComponent(InActorComp) {}
+	FActorComponentWrapper(TObjectPtr<const UActorComponent> InActorComp) : ActorComponent(InActorComp) {}
 
-	void SetComponent(const UActorComponent* InActorComp) { ActorComponent = InActorComp; }
+	void SetComponent(TObjectPtr<const UActorComponent> InActorComp) { ActorComponent = InActorComp; }
 	void ClearComponent() { ActorComponent = nullptr; }
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = ActorComponent)
-		const UActorComponent* ActorComponent;
+	TObjectPtr<const UActorComponent> ActorComponent;
 };
 
 
@@ -434,10 +434,10 @@ struct FActorHitProxyInfo
 	GENERATED_USTRUCT_BODY()
 
 		UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = ActorHitProxyInfo)
-		AActor* Actor;
+		TObjectPtr<AActor> Actor;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = ActorHitProxyInfo)
-		const UPrimitiveComponent* PrimitiveComponent;
+	TObjectPtr<const UPrimitiveComponent> PrimitiveComponent;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = ActorHitProxyInfo)
 		int32 SectionIndex;


### PR DESCRIPTION
This is the new standard way to use pointers. There is an build setting which we have enabled that requires pointers to be formatted this way.

For a little more information you can read about enforcing `TObjectPtr` here: [Enforce TObjectPtr! (And how to avoid pitfalls)](https://www.thegames.dev/?p=279)

### GameEditor.Target.cs
```cs
NativePointerMemberBehaviorOverride = PointerMemberBehavior.Disallow;
```
